### PR TITLE
Set empty default values for reverse location

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -701,10 +701,11 @@ class Manager(object):
 
     # Returns the name of the location based on lat and lng
     def reverse_location(self, lat, lng):
+        details = {'street_num':'', 'street':'', 'address':'', 'postal':'', 'neighborhood':'',
+                   'sublocality':'', 'city':'', 'county':'', 'state':'', 'country':''}
         if self.__gmaps_client is None:  # Check if key was provided
             log.error("No Google Maps API key provided - unable to reverse geocode.")
-            return {}
-        details = {}
+            return details
         try:
             result = self.__gmaps_client.reverse_geocode((lat, lng))[0]
             loc = {}


### PR DESCRIPTION
## Description
Set empty default values for reverse location to make sure that the markers aren't printed in the messages pushed by PokeAlarm

## How Has This Been Tested?
location lookup failes about once a day, before it generated errors like on the screen below, now the fields are simply empty.

## Screenshots (if appropriate):
before
![pkmn](https://cloud.githubusercontent.com/assets/22026252/23202811/1cd3edf6-f8e0-11e6-8eee-cda539a8294d.png)
after
![pkmn](https://cloud.githubusercontent.com/assets/22026252/23329308/5d595ebc-fb36-11e6-97ee-0f50e5151095.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
not needed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.